### PR TITLE
Show error message when response body contains an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (options) {
 			gutil.log(PLUGIN, gutil.colors.red("Clodflare server not responding:("));
 			return;
 		}
-		if(res.statusCode !== 200) {
+		if(res.statusCode !== 200 || res.body.result === 'error') {
 			var errorMessage = "Not able to purge cache.";
 			if(res.body && res.body.msg) {
 				errorMessage = res.body.msg;


### PR DESCRIPTION
Cloudflare returns status code 200 even if response body contains an error.

For example:

```
{ result: 'error',
  msg: 'Invalid token or email',
  err_code: 'E_UNAUTH' }
```
